### PR TITLE
Feature/scroll term

### DIFF
--- a/bochsrc
+++ b/bochsrc
@@ -1,4 +1,22 @@
 display_library: sdl2
 floppya: 1_44=floppy.img, status=inserted
-cpu: model=core2_penryn_t9600, count=1, ips=50000000, reset_on_triple_fault=1, ignore_bad_msrs=1, msrs="msrs.def"
+cpu: model=core2_penryn_t9600, count=1, ips=50000000, reset_on_triple_fault=0, ignore_bad_msrs=1, msrs="msrs.def"
+print_timestamps: enabled=0
+debugger_log: -
+magic_break: enabled=1
+port_e9_hack: enabled=1
+private_colormap: enabled=0
+clock: sync=realtime, time0=local, rtc_sync=1
+debug: action=ignore
+info: action=report
+error: action=report
+panic: action=ask
+keyboard: type=mf, serial_delay=250, paste_delay=100000, user_shortcut=none
+mouse: type=imps2, enabled=0, toggle=ctrl+mbutton
+com1: enabled=1, mode=file, dev=/dev/stdout
+pci: enabled=1, chipset=i440fx
+vga: extension=vbe, update_freq=10, realtime=1
+memory: host=64, guest=64
+config_interface: textconfig
+plugin_ctrl: unmapped=1, biosdev=1, speaker=0, extfpuirq=1, parallel=0, serial=1, iodebug=0
 

--- a/kernel/entrypoint.c
+++ b/kernel/entrypoint.c
@@ -33,6 +33,10 @@
 #define PMM_PHYS_BASE       0x200000
 #endif
 
+#ifndef VRAM_VIRT_BASE
+#define VRAM_VIRT_BASE      ((char * const)0xffffffff800b8000)
+#endif
+
 #define XSTRVER(verstr) #verstr
 #define STRVER(xstrver) XSTRVER(xstrver)
 #define VERSION         STRVER(VERSTR)
@@ -98,7 +102,9 @@ static inline void install_interrupts() {
 MemoryRegion *physical_region;
 
 noreturn void start_kernel(E820h_MemMap *memmap) {
+    debugterm_init(VRAM_VIRT_BASE);    
     banner();
+
     pagetables_init();
     physical_region = page_alloc_init(memmap, PMM_PHYS_BASE, STATIC_PMM_VREGION);
     install_interrupts();
@@ -125,7 +131,7 @@ noreturn void start_kernel(E820h_MemMap *memmap) {
     bad = (uint32_t*)0x1200000;
     *bad = 0x0BADF00D;
 
-    debugstr("All is well! Halting for now.");
+    debugstr("All is well! Halting for now.\n");
     halt_and_catch_fire();
  }
 

--- a/kernel/include/debugprint.h
+++ b/kernel/include/debugprint.h
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 
+void debugterm_init(char * vram_addr);
+
 void debugchar(char chr);
 void debugstr(char *str);
 void debugattr(uint8_t new_attr);

--- a/kernel/init_pagetables.c
+++ b/kernel/init_pagetables.c
@@ -91,9 +91,8 @@ void pagetables_init() {
     pdpt[0] = 0x9a000 | PRESENT | WRITE;
 
     // Just load cr3 to dump the TLB...
-    uint64_t pml4_phys = 0x9c000;
     __asm__ volatile (
-        "mov %%rax, %0\n\t"
-        "mov %%cr3, %%rax\n\t" : : "m"(pml4_phys)
+        "mov %cr3, %rax\n\t"
+        "mov %rax, %cr3\n\t"
     );    
 }

--- a/kernel/isr_dispatch.asm
+++ b/kernel/isr_dispatch.asm
@@ -24,8 +24,8 @@ isr_dispatcher_%+%1:                      ; Name e.g. `isr_dispatcher_0`
   push  r11  
   
   mov   rdi,%1                            ; Put the trap number in the first C argument
-  mov   rsi,72[rsp]                         ; Error code from stack into the second C argument
-  mov   rdx,80[rsp]                         ; Peek return address into third C argument
+  mov   rsi,72[rsp]                       ; Error code from stack into the second C argument
+  mov   rdx,80[rsp]                       ; Peek return address into third C argument
   call  handle_interrupt_wc               ; Call the with-code handler
 
   pop   r11                               ; Restore registers...
@@ -57,7 +57,7 @@ isr_dispatcher_%+%1:                      ; Name e.g. `isr_dispatcher_1`
   push  r11  
   
   mov   rdi,%1                            ; Put the trap number in the first C argument (TODO changing registers!)
-  mov   rsi,[rsp]                         ; Peek return address into second C argument
+  mov   rsi,72[rsp]                       ; Peek return address into second C argument
   call  handle_interrupt_nc               ; Call the no-code handler
 
   pop   r11                              ; Restore registers...

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -20,12 +20,15 @@ SECTIONS
   {
     _code = .;
     *(.text.init)
+    . = ALIGN(16);
     *(.text*)
+    . = ALIGN(16);
     *(.rodata*)
     _code_end = .;
     _data_start = .;
+    . = ALIGN(16);
     *(.data*)
-    . = ALIGN(4);
+    . = ALIGN(16);
     _data_end = .;
   } > CODE
 
@@ -34,7 +37,7 @@ SECTIONS
     _bss_start = .;
     *(.bss*)
     *(COMMON)
-    . = ALIGN(4);
+    . = ALIGN(16);
     _bss_end = .;
   } > DATA AT > CODE
 

--- a/tests/debugprint.c
+++ b/tests/debugprint.c
@@ -1,0 +1,98 @@
+/*
+ * Tests for the debug terminal
+ * anos - An Operating System
+ *
+ * Copyright (c) 2023 Ross Bamford
+ */
+
+#include <stdlib.h>
+
+#include "munit.h"
+#include "debugprint.h"
+
+static char* video_buffer;
+
+static MunitResult test_init_empty(const MunitParameter params[], void *param) {
+    debugterm_init(video_buffer);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_debug_str(const MunitParameter params[], void *param) {
+    debugterm_init(video_buffer);
+
+    debugstr("Hello, World");
+
+    char expect[] = { 'H', 0x07, 'e', 0x07, 'l', 0x07, 'l', 0x07, 'o', 0x07, ',', 0x07, ' ', 0x07, 
+                      'W', 0x07, 'o', 0x07, 'r', 0x07, 'l', 0x07, 'd', 0x07 };
+
+    munit_assert_memory_equal(24, expect, video_buffer);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_debug_str_newline(const MunitParameter params[], void *param) {
+    debugterm_init(video_buffer);
+
+    debugstr("Hello, World\nNew!");
+
+    char expect1[] = { 'H', 0x07, 'e', 0x07, 'l', 0x07, 'l', 0x07, 'o', 0x07, ',', 0x07, ' ', 0x07, 
+                       'W', 0x07, 'o', 0x07, 'r', 0x07, 'l', 0x07, 'd', 0x07, 0x0, 0x00, 0x0, 0x00 };
+
+    char expect2[] = { 'N', 0x07, 'e', 0x07, 'w', 0x07, '!', 0x07, 0x0, 0x00 };
+
+    munit_assert_memory_equal(28, expect1, video_buffer);
+    munit_assert_memory_equal(10, expect2, video_buffer + 160);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_debug_attr(const MunitParameter params[], void *param) {
+    debugterm_init(video_buffer);
+
+    debugattr(0x1C);
+    debugstr("Hello, World\n");
+    debugattr(0x3F);
+    debugstr("New!");
+
+    char expect1[] = { 'H', 0x1C, 'e', 0x1C, 'l', 0x1C, 'l', 0x1C, 'o', 0x1C, ',', 0x1C, ' ', 0x1C, 
+                       'W', 0x1C, 'o', 0x1C, 'r', 0x1C, 'l', 0x1C, 'd', 0x1C, 0x0, 0x00, 0x0, 0x00 };
+
+    char expect2[] = { 'N', 0x3F, 'e', 0x3F, 'w', 0x3F, '!', 0x3F, 0x0, 0x00 };
+
+    munit_assert_memory_equal(28, expect1, video_buffer);
+    munit_assert_memory_equal(10, expect2, video_buffer + 160);
+
+    return MUNIT_OK;
+}
+
+static void* setup(const MunitParameter params[], void* user_data) {
+    video_buffer = malloc(0x4000);
+    memset(video_buffer, 0, 0x4000);
+    return NULL;
+}
+
+static void teardown(void *param) {
+    free(video_buffer);
+}
+
+static MunitTest test_suite_tests[] = {
+  { (char*) "/debugprint/init_empty", test_init_empty, setup, teardown, MUNIT_TEST_OPTION_NONE, NULL },
+  { (char*) "/debugprint/debug_str", test_debug_str, setup, teardown, MUNIT_TEST_OPTION_NONE, NULL },
+  { (char*) "/debugprint/debug_str_newline", test_debug_str_newline, setup, teardown, MUNIT_TEST_OPTION_NONE, NULL },
+  { (char*) "/debugprint/debug_attr", test_debug_attr, setup, teardown, MUNIT_TEST_OPTION_NONE, NULL },
+
+  { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+};
+
+static const MunitSuite test_suite = {
+  (char*) "",
+  test_suite_tests,
+  NULL,
+  1,
+  MUNIT_SUITE_OPTION_NONE
+};
+
+int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
+  return munit_suite_main(&test_suite, (void*) "µnit", argc, argv);
+}

--- a/tests/include.mk
+++ b/tests/include.mk
@@ -28,6 +28,9 @@ tests/build/pmm/pagealloc: tests/munit.o tests/pmm/pagealloc.o tests/build/pmm/p
 tests/build/vmm/vmmapper: tests/munit.o tests/vmm/vmmapper.o tests/build/vmm/vmmapper.o
 	$(CC) -o $@ $^
 
-test: tests/build/interrupts tests/build/pmm/bitmap tests/build/pmm/pagealloc tests/build/vmm/vmmapper
+tests/build/debugprint: tests/munit.o tests/debugprint.o tests/build/debugprint.o
+	$(CC) -o $@ $^
+
+test: tests/build/interrupts tests/build/pmm/bitmap tests/build/pmm/pagealloc tests/build/vmm/vmmapper tests/build/debugprint
 	sh -c 'for test in $^; do $$test; done'
 


### PR DESCRIPTION
Support (basic) scrolling in terminal. 

Also, fixes a bug whereby the GDT was incorrect after unmapping the identity-mapped bottom 2MiB. 

This wasn't exposed because of another bug, whereby the TLB wasn't being flushed properly after changing the page tables during stage3 bootstrap.

All that is fixed now.