### PR TITLE
Feature/fix user gs

### DIFF
--- a/kernel/include/smp/state.h
+++ b/kernel/include/smp/state.h
@@ -43,9 +43,8 @@ typedef struct PerCPUState {
     uint8_t task_data[STATE_TASK_DATA_MAX];   // takes us to 960 bytes
 
     SleepQueue sleep_queue; // takes us to 1024 bytes
-    uint64_t usp_stash;     // 1032
 
-    uint8_t reserved3[3064]; // takes us to 4096 bytes
+    uint8_t reserved3[3065]; // takes us to 4096 bytes
 } PerCPUState;
 
 static_assert_sizeof(PerCPUState, ==, VM_PAGE_SIZE);

--- a/kernel/init_syscalls.asm
+++ b/kernel/init_syscalls.asm
@@ -28,6 +28,7 @@ extern handle_syscall_69
 
 %include "smp/state.inc"
 
+%define TASK_USP    56
 %define TASK_RSP0   24
 
 %macro write_msr 2
@@ -88,9 +89,9 @@ syscall_enter:
     ;      (specifically tasks crash when waking from sleep, so I think we're 
     ;      missing an equivalent stack switch somewhere in that path...)
     ;   
-    mov     r8,[gs:CPU_TASK_CURRENT]       ; ... and load task pointer
-    mov     [r8+8],rsp         ; Stash the user stack pointer
-    mov     rsp,[r8+TASK_RSP0]             ; ... so we can switch to kernel stack
+    mov     r8,[gs:CPU_TASK_CURRENT]        ; Load current task from CPU data
+    mov     [r8+TASK_USP],rsp               ; And stash rsp there
+    mov     rsp,[r8+TASK_RSP0]              ; ... so we can switch to kernel stack
 %endif
 
     push rbp
@@ -116,8 +117,8 @@ syscall_enter:
     pop rbp
 %ifndef NO_USER_GS
     cli
-    mov     r8,[gs:CPU_TASK_CURRENT]       ; ... and load task pointer
-    mov     rsp,[r8+8]          ; ... and restore the user stack pointer
+    mov     r8,[gs:CPU_TASK_CURRENT]        ; Load current task from CPU data
+    mov     rsp,[r8+TASK_USP]               ; ... and restore the user stack pointer
 
     swapgs
 %endif

--- a/kernel/init_syscalls.asm
+++ b/kernel/init_syscalls.asm
@@ -88,9 +88,9 @@ syscall_enter:
     ;      (specifically tasks crash when waking from sleep, so I think we're 
     ;      missing an equivalent stack switch somewhere in that path...)
     ;   
-    ; mov     [gs:CPU_RSP_STASH+16],rsp      ; Stash the user stack pointer
-    ; mov     r8,[gs:CPU_TASK_CURRENT]       ; ... and load task pointer
-    ; mov     rsp,[r8+TASK_RSP0]             ; ... so we can switch to kernel stack
+    mov     r8,[gs:CPU_TASK_CURRENT]       ; ... and load task pointer
+    mov     [r8+8],rsp         ; Stash the user stack pointer
+    mov     rsp,[r8+TASK_RSP0]             ; ... so we can switch to kernel stack
 %endif
 
     push rbp
@@ -116,7 +116,8 @@ syscall_enter:
     pop rbp
 %ifndef NO_USER_GS
     cli
-    ; mov     rsp,[gs:CPU_RSP_STASH+16]          ; ... and restore the user stack pointer
+    mov     r8,[gs:CPU_TASK_CURRENT]       ; ... and load task pointer
+    mov     rsp,[r8+8]          ; ... and restore the user stack pointer
 
     swapgs
 %endif

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -13,7 +13,9 @@
 
 #include "debugprint.h"
 #include "machine.h"
+#include "printdec.h"
 #include "printhex.h"
+#include "smp/state.h"
 #include "spinlock.h"
 
 #define IS_KERNEL_CODE(addr) (((addr & 0xFFFFFFFF80000000) != 0))
@@ -72,6 +74,11 @@ noreturn void panic_page_fault(uintptr_t origin_addr, uintptr_t fault_addr,
     debugstr("PANIC");
     debugattr(0x0C);
     debugstr("         : Unhandled page fault (0x0e)");
+
+    PerCPUState *cpu_state = state_get_per_cpu();
+    debugstr("\nCPU           : ");
+    printdec(cpu_state->cpu_id, debugchar);
+
     debugstr("\nCode          : ");
     printhex64(code, debugchar);
     debug_page_fault_code(code);
@@ -96,7 +103,13 @@ noreturn void panic_general_protection_fault(uint64_t code,
     debugstr("PANIC");
     debugattr(0x0C);
 
-    debugstr("         : General Protection Fault (0x0d)\nCode          : ");
+    debugstr("         : General Protection Fault (0x0d)");
+
+    PerCPUState *cpu_state = state_get_per_cpu();
+    debugstr("\nCPU           : ");
+    printdec(cpu_state->cpu_id, debugchar);
+
+    debugstr("\nCode          : ");
     printhex64(code, debugchar);
     debugstr("\nOrigin IP     : ");
     printhex64(origin_addr, debugchar);

--- a/kernel/structs/pq.c
+++ b/kernel/structs/pq.c
@@ -75,7 +75,7 @@ void task_pq_push(TaskPriorityQueue *pq, Task *new_node) {
         return;
     }
 
-    if (pq->head == NULL || new_node->prio < pq->head->prio) {
+    if (pq->head == NULL || new_node->sched->prio < pq->head->sched->prio) {
         new_node->this.next = (ListNode *)pq->head;
         pq->head = new_node;
         return;
@@ -83,7 +83,7 @@ void task_pq_push(TaskPriorityQueue *pq, Task *new_node) {
 
     Task *current = pq->head;
     while (current->this.next != NULL &&
-           ((Task *)current->this.next)->prio <= new_node->prio) {
+           ((Task *)current->this.next)->sched->prio <= new_node->sched->prio) {
         current = (Task *)current->this.next;
     }
 

--- a/kernel/structs/pq.c
+++ b/kernel/structs/pq.c
@@ -51,11 +51,11 @@ static bool check_invariants(TaskPriorityQueue *pq) {
         }
 
         // priority ordering
-        if (slow->prio > ((Task *)slow->this.next)->prio) {
+        if (slow->sched->prio > ((Task *)slow->this.next)->sched->prio) {
             debugstr("Error: Priority ordering violation: ");
-            printdec(slow->prio, debugchar);
+            printdec(slow->sched->prio, debugchar);
             debugstr(" > ");
-            printdec(((Task *)slow->this.next)->prio, debugchar);
+            printdec(((Task *)slow->this.next)->sched->prio, debugchar);
             debugstr("\n");
             return false;
         }

--- a/kernel/syscalls.c
+++ b/kernel/syscalls.c
@@ -64,7 +64,7 @@ static SyscallResult handle_create_thread(ThreadFunc func,
     sched_unblock(task);
     sched_unlock();
 
-    return task->tid;
+    return task->sched->tid;
 }
 
 static SyscallResult handle_memstats(AnosMemInfo *mem_info) {

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -101,9 +101,13 @@ void kernel_thread_entrypoint(void);
 
 Task *task_create_new(Process *owner, uintptr_t sp, uintptr_t sys_ssp,
                       uintptr_t bootstrap, uintptr_t func, TaskClass class) {
+
+    TaskSched *sched = slab_alloc_block();
     Task *task = slab_alloc_block();
 
-    task->tid = next_tid++;
+    task->sched = sched;
+
+    task->sched->tid = next_tid++;
 
     if (sys_ssp) {
         task->rsp0 = task->ssp = sys_ssp;
@@ -134,13 +138,13 @@ Task *task_create_new(Process *owner, uintptr_t sp, uintptr_t sys_ssp,
 
     task->owner = owner;
     task->pml4 = owner->pml4;
-    task->ts_remain = DEFAULT_TIMESLICE;
-    task->state = TASK_STATE_READY;
+    task->sched->ts_remain = DEFAULT_TIMESLICE;
+    task->sched->state = TASK_STATE_READY;
 
     // TODO pass these in, or inherit from owner
     //      if the latter, have a separate call to change them...
-    task->class = class;
-    task->prio = 0;
+    task->sched->class = class;
+    task->sched->prio = 0;
 
     task->this.next = (void *)0;
     task->this.type = KTYPE_TASK;


### PR DESCRIPTION
**Note**: This doesn't quite fix _all_ of the problems - we still have a race condition whereby kernel threads will sometimes raise `#GP`, I _believe_ when they wake from sleep.

This hits the `iretq` at the end of the ISR dispatcher for the APIC timer on the APs, which probably means the stack is corrupt. I suspect we're missing a `cli` somewhere, or are otherwise somehow entering that routine twice on the same stack.