### PR TITLE
Implement COW for new processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,6 @@ endif
 #
 # These ones enable some specific feature tests
 #
-#	DEBUG_FORCE_HANDLED_PAGE_FAULT		Force a handled page-fault at boot
-#	DEBUG_FORCE_UNHANDLED_PAGE_FAULT	Force an unhandled page-fault at boot
 #	DEBUG_NO_START_SYSTEM				Don't start the user-mode supervisor
 #	DEBUG_SLEEPY_KERNEL_TASK			Start a noisy kernel task that sleeps on all CPUs
 #	SYSCALL_SCHED_ONLY_THIS_CPU			Syscalls will only schedule things on the current CPU

--- a/kernel/arch/x86_64/include/process/address_space.h
+++ b/kernel/arch/x86_64/include/process/address_space.h
@@ -34,7 +34,7 @@ bool address_space_init(void);
  *
  * * Allocate a new address space
  * * Copy all kernel PDPTs into it
- * * Map the space covered by `shared_space_start` / `shared_space_start` as readonly shared
+ * * Map the space covered by `regions` as COW shared
  * * Allocate pages to cover `init_stack_len` bytes and map it at `init_stack_vaddr`.
  * 
  * Currently, on failure, this will leak some memory - that'll be fixed once

--- a/kernel/arch/x86_64/process/address_space.c
+++ b/kernel/arch/x86_64/process/address_space.c
@@ -191,6 +191,7 @@ uintptr_t address_space_create(uintptr_t init_stack_vaddr,
 
         for (uintptr_t ptr = regions[i].start; ptr < region_end;
              ptr += VM_PAGE_SIZE) {
+
             debugstr("Copying ");
             printhex64(ptr, debugchar);
             debugstr("\n");
@@ -201,13 +202,13 @@ uintptr_t address_space_create(uintptr_t init_stack_vaddr,
                 // TODO what if this fails (to alloc table pages)?
                 //
                 vmm_map_page_in(new_pml4_virt, ptr, shared_phys,
-                                PRESENT | USER);
+                                PRESENT | USER | COPY_ON_WRITE);
 
                 // TODO pmm_free_shareable(page) needs implementing to check this and handle appropriately...
                 //
                 refcount_map_increment(shared_phys);
 
-                debugstr("    Copied a page...\n");
+                debugstr("    Copied a page mapping as COW...\n");
             } else {
                 debugstr("    [... skipped, not present]\n");
             }

--- a/kernel/entrypoint.c
+++ b/kernel/entrypoint.c
@@ -204,48 +204,6 @@ noreturn void bsp_kernel_entrypoint(uintptr_t rsdp_phys) {
 
     pci_enumerate();
 
-#ifdef DEBUG_FORCE_HANDLED_PAGE_FAULT
-    debugstr("\nForcing a (handled) page fault with write to "
-             "0xFFFFFFFF80600000...\n");
-
-    // Force a page fault for testing purpose. This one should get handled and a
-    // page mapped...
-    uint32_t *bad = (uint32_t *)0xFFFFFFFF80600000;
-    *bad = 0x0A11C001;
-    debugstr("Continued after fault, write succeeded. Value is ");
-    debugattr(0x02);
-    printhex32(*bad, debugchar);
-    debugattr(0x07);
-    debugstr("\n");
-#endif
-
-#ifdef DEBUG_FORCE_UNHANDLED_PAGE_FAULT
-    // Map a page, write to it, read it back, then unmap and attempt to read
-    // again. Should force an unhandled page fault.
-    debugstr("Forcing unhandled page fault and testing vmm_map / vmm_unmap at "
-             "the same time...\n");
-    volatile uint64_t *volatile ptr = (uint64_t *)0x400000000;
-    uint64_t tpage = page_alloc(physical_region);
-    vmm_map_page(0x400000000, tpage, WRITE | PRESENT);
-
-    *ptr = 0x12345678;
-
-    debugstr("Mapped & set: now ");
-    printhex64(*ptr, debugchar);
-    debugstr("\n");
-
-    uintptr_t old = vmm_unmap_page(0x400000000);
-    debugstr("Unmapped - phys was ");
-    printhex64(old, debugchar);
-    debugstr("; should equal ");
-    printhex64(tpage, debugchar);
-    debugstr("\n");
-
-    debugstr("Attempting read - should panic here...\n");
-    printhex64(*ptr, debugchar);
-    debugstr("\n");
-#endif
-
 #ifdef DEBUG_NO_START_SYSTEM
     debugstr("All is well, DEBUG_NO_START_SYSTEM was specified, so halting for "
              "now.\n");

--- a/kernel/include/structs/ref_count_map.h
+++ b/kernel/include/structs/ref_count_map.h
@@ -71,9 +71,25 @@ static_assert_sizeof(Entry, ==, 64);
 static_assert_sizeof(BlockNode, ==, 64);
 static_assert_sizeof(RefCountMap, ==, 64);
 
+/*
+ * Initialize - must be called before other routines are used!
+ * (entrypoint handles that...)
+ */
 bool refcount_map_init(void);
+
+/*
+ * Increment the reference count for the given address.
+ * 
+ * Returns the new reference count for that address, or 0 on error.
+ */
 uint32_t refcount_map_increment(uintptr_t addr);
+
+/*
+ * Decrement the reference count for the given address.
+ * 
+ * Returns the **previous** reference count for that address,
+ * or 0 if no reference count (or error).
+ */
 uint32_t refcount_map_decrement(uintptr_t addr);
-void refcount_map_cleanup(void);
 
 #endif //__ANOS_KERNEL_REF_COUNT_MAP_H

--- a/kernel/include/vmm/vmmapper.h
+++ b/kernel/include/vmm/vmmapper.h
@@ -51,6 +51,11 @@
 #define USER ((1 << 2))
 
 /*
+ * Page COW attribute (STAGE3-specific)
+ */
+#define COPY_ON_WRITE ((1 << 6))
+
+/*
  * Page size attribute (for large pages)
  */
 #define PAGESIZE ((1 << 7))
@@ -58,13 +63,26 @@
 // Again, for now, all physical memory used must be mapped
 // here, the mapper expects to be able to access pages
 // under this...
-#define STATIC_KERNEL_SPACE 0xFFFFFFFF80000000
+#define STATIC_KERNEL_SPACE ((0xFFFFFFFF80000000))
 
 // Just used to page-align addresses to their containing page
-#define PAGE_ALIGN_MASK 0xFFFFFFFFFFFFF000
+#define PAGE_ALIGN_MASK ((0xFFFFFFFFFFFFF000))
 
 // Just used to extract page-relative addresses from their containing page
 #define PAGE_RELATIVE_MASK (~PAGE_ALIGN_MASK)
+
+// Just used to extract PTE flags
+#define PAGE_FLAGS_MASK PAGE_RELATIVE_MASK
+
+// Base of the per-CPU temporary mapping pages
+#define PER_CPU_TEMP_PAGE_BASE ((0xFFFFFFFF80400000))
+
+/*
+ *  Find the per-CPU temporary page base for the given CPU.
+ */
+static inline uintptr_t vmm_per_cpu_temp_page_addr(uint8_t cpu) {
+    return PER_CPU_TEMP_PAGE_BASE + (cpu << 12);
+}
 
 /*
  * Map the given page-aligned physical address into virtual memory 

--- a/kernel/structs/ref_count_map.c
+++ b/kernel/structs/ref_count_map.c
@@ -280,10 +280,10 @@ uint32_t refcount_map_decrement(uintptr_t addr) {
                 slab_free(entry);
                 map->num_entries--;
                 SPINLOCK_UNLOCK();
-                return 0;
+                return 1;
             }
 
-            uint32_t result = entry->ref_count;
+            uint32_t result = entry->ref_count + 1;
             SPINLOCK_UNLOCK();
             return result;
         }
@@ -295,7 +295,7 @@ uint32_t refcount_map_decrement(uintptr_t addr) {
     return 0; // Address not found
 }
 
-// TODO probably don't need this..?
+#ifdef UNIT_TESTS
 void refcount_map_cleanup(void) {
     SPINLOCK_LOCK();
 
@@ -330,3 +330,4 @@ void refcount_map_cleanup(void) {
 
     SPINLOCK_UNLOCK();
 }
+#endif

--- a/kernel/tests/structs/ref_count_map.c
+++ b/kernel/tests/structs/ref_count_map.c
@@ -18,6 +18,8 @@
 #include "mock_slab.h"
 #include "mock_spinlock.h"
 
+void refcount_map_cleanup(void);
+
 // Test initialization
 static MunitResult test_init(const MunitParameter params[], void *data) {
     // Test successful initialization
@@ -90,11 +92,11 @@ static MunitResult test_basic_refcount(const MunitParameter params[],
 
     // Remove one reference
     count = refcount_map_decrement(addr);
-    munit_assert_uint32(count, ==, 1);
+    munit_assert_uint32(count, ==, 2);
 
     // Remove last reference
     count = refcount_map_decrement(addr);
-    munit_assert_uint32(count, ==, 0);
+    munit_assert_uint32(count, ==, 1);
 
     // Try to remove non-existent reference
     count = refcount_map_decrement(addr);
@@ -123,11 +125,11 @@ static MunitResult test_multiple_addresses(const MunitParameter params[],
     munit_assert_uint32(refcount_map_increment(addr2), ==, 3);
 
     // Remove references in mixed order
-    munit_assert_uint32(refcount_map_decrement(addr1), ==, 0);
+    munit_assert_uint32(refcount_map_decrement(addr1), ==, 1);
+    munit_assert_uint32(refcount_map_decrement(addr2), ==, 3);
+    munit_assert_uint32(refcount_map_decrement(addr3), ==, 1);
     munit_assert_uint32(refcount_map_decrement(addr2), ==, 2);
-    munit_assert_uint32(refcount_map_decrement(addr3), ==, 0);
     munit_assert_uint32(refcount_map_decrement(addr2), ==, 1);
-    munit_assert_uint32(refcount_map_decrement(addr2), ==, 0);
 
     refcount_map_cleanup();
     return MUNIT_OK;
@@ -171,7 +173,7 @@ static MunitResult test_resize(const MunitParameter params[], void *data) {
         uint32_t count = refcount_map_increment(addr);
         munit_assert_uint32(count, ==, 2);
         count = refcount_map_decrement(addr);
-        munit_assert_uint32(count, ==, 1);
+        munit_assert_uint32(count, ==, 2);
     }
 
     refcount_map_cleanup();

--- a/system/main.c
+++ b/system/main.c
@@ -36,6 +36,8 @@ static uint8_t t2_stack[4096];
 static uint8_t t3_stack[4096];
 static uint8_t t4_stack[4096];
 
+volatile int num2;
+
 static inline void banner() {
     printf("\n\nSYSTEM User-mode Supervisor #%s [libanos #%s]\n", VERSION,
            libanos_version());
@@ -106,6 +108,12 @@ static noreturn int other_main(void) {
     anos_kprint("Beep Boop process is up...\n");
 
     while (1) {
+        // This is testing copy-on-write is working...
+        // num2 is in SYSTEM's data area, mapped copy-on-write
+        // into the new process call. This will generate #PF
+        // and the handler will sort out the copy...
+        num2 += 1;
+
         anos_task_sleep_current_secs(10);
         anos_kprint("<beep>");
         anos_task_sleep_current_secs(10);


### PR DESCRIPTION
This PR also removes the (very) old `FORCE_xxx_PAGE_FAULT` testing flags and gets rid of the concept of Kernel Automap space, which was just left over from _very_ early debugging code and isn't useful any more.

Automap space is now replaced with 256 per-CPU 4KiB pages (a total of 1MiB) that are used for temporary mapping.