### PR TITLE
Feature/tlb shootdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,7 @@ STAGE3_OBJS=$(STAGE3_DIR)/entrypoint.o											\
 			$(STAGE3_DIR)/structs/region_tree.o									\
 			$(STAGE3_DIR)/structs/shift_array.o									\
 			$(STAGE3_DIR)/smp/ipwi.o											\
+			$(STAGE3_DIR)/vmm/vmm_shootdown.o									\
 			$(STAGE3_ARCH_OBJS)													\
 			$(SYSTEM)_linkable.o
 else

--- a/kernel/arch/riscv64/vmm/vmmapper.c
+++ b/kernel/arch/riscv64/vmm/vmmapper.c
@@ -121,17 +121,16 @@ inline void vmm_invalidate_page(uintptr_t virt_addr) {
     cpu_invalidate_tlb_addr(virt_addr);
 }
 
-bool vmm_map_page_containing_in(uint64_t *pml4, uintptr_t virt_addr,
-                                const uint64_t phys_addr,
-                                const uint16_t flags) {
-    uint64_t lock_flags = spinlock_lock_irqsave(&vmm_map_lock);
+static bool nolock_vmm_map_page_containing_in(uint64_t *pml4,
+                                              uintptr_t virt_addr,
+                                              const uint64_t phys_addr,
+                                              const uint16_t flags) {
 
     virt_addr &= PAGE_ALIGN_MASK;
 
     uint64_t *pt = ensure_tables(pml4, virt_addr, PT_LEVEL_PT);
 
     if (!pt) {
-        spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
         return false;
     }
 
@@ -140,8 +139,17 @@ bool vmm_map_page_containing_in(uint64_t *pml4, uintptr_t virt_addr,
 
     vmm_invalidate_page(virt_addr);
 
-    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
     return true;
+}
+
+inline bool vmm_map_page_containing_in(uint64_t *pml4, uintptr_t virt_addr,
+                                       const uint64_t phys_addr,
+                                       const uint16_t flags) {
+    uint64_t lock_flags = spinlock_lock_irqsave(&vmm_map_lock);
+    const bool result = nolock_vmm_map_page_containing_in(pml4, virt_addr,
+                                                          phys_addr, flags);
+    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
+    return result;
 }
 
 inline bool vmm_map_page_containing(const uintptr_t virt_addr,
@@ -152,19 +160,55 @@ inline bool vmm_map_page_containing(const uintptr_t virt_addr,
             virt_addr, phys_addr, flags);
 }
 
-inline bool vmm_map_page_in(uint64_t *pml4, const uintptr_t virt_addr,
-                            const uint64_t page, const uint16_t flags) {
+bool vmm_map_page_in(uint64_t *pml4, const uintptr_t virt_addr,
+                     const uint64_t page, const uint16_t flags) {
     return vmm_map_page_containing_in(pml4, virt_addr, page, flags);
 }
 
-inline bool vmm_map_page(const uintptr_t virt_addr, const uint64_t page,
-                         const uint16_t flags) {
+bool vmm_map_page(const uintptr_t virt_addr, const uint64_t page,
+                  const uint16_t flags) {
     return vmm_map_page_containing(virt_addr, page, flags);
 }
 
-uintptr_t vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
-    uint64_t lock_flags = spinlock_lock_irqsave(&vmm_map_lock);
+inline bool vmm_map_pages_containing_in(uint64_t *pml4, uintptr_t virt_addr,
+                                        const uint64_t phys_addr,
+                                        const uint16_t flags,
+                                        const size_t num_pages) {
 
+    uint64_t lock_flags = spinlock_lock_irqsave(&vmm_map_lock);
+    for (int i = 0; i < num_pages; i++) {
+        if (!nolock_vmm_map_page_containing_in(
+                    pml4, virt_addr + (i << VM_PAGE_LINEAR_SHIFT),
+                    phys_addr + (i << VM_PAGE_LINEAR_SHIFT), flags)) {
+            return false;
+        }
+    }
+    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
+    return true;
+}
+
+inline bool vmm_map_pages_containing(const uintptr_t virt_addr,
+                                     const uint64_t phys_addr,
+                                     const uint16_t flags,
+                                     const size_t num_pages) {
+
+    return vmm_map_pages_containing_in(
+            vmm_phys_to_virt_ptr(cpu_satp_to_root_table_phys(cpu_read_satp())),
+            virt_addr, phys_addr, flags, num_pages);
+}
+
+bool vmm_map_pages_in(uint64_t *pml4, const uintptr_t virt_addr,
+                      const uint64_t page, const uint16_t flags,
+                      const size_t num_pages) {
+    return vmm_map_pages_containing_in(pml4, virt_addr, page, flags, num_pages);
+}
+
+bool vmm_map_pages(const uintptr_t virt_addr, const uint64_t page,
+                   const uint16_t flags, const size_t num_pages) {
+    return vmm_map_pages_containing(virt_addr, page, flags, num_pages);
+}
+
+static uintptr_t nolock_vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
     const uint16_t pml4_index = vmm_virt_to_pml4_index(virt_addr);
     uint64_t pml4e = pml4[pml4_index];
 
@@ -175,7 +219,6 @@ uintptr_t vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
 
             vmm_invalidate_page(virt_addr);
 
-            spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
             return vmm_table_entry_to_phys(pml4e);
         }
 
@@ -190,7 +233,6 @@ uintptr_t vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
 
                 vmm_invalidate_page(virt_addr);
 
-                spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
                 return vmm_table_entry_to_phys(pdpte);
             }
 
@@ -204,7 +246,6 @@ uintptr_t vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
                     pd[pd_index] = 0;
                     vmm_invalidate_page(virt_addr);
 
-                    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
                     return vmm_table_entry_to_phys(pde);
                 }
 
@@ -219,18 +260,42 @@ uintptr_t vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
 
                     vmm_invalidate_page(virt_addr);
 
-                    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
                     return vmm_table_entry_to_phys(pte);
                 }
             }
         }
     }
 
-    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
     return 0;
 }
 
-inline uintptr_t vmm_unmap_page(const uintptr_t virt_addr) {
+inline uintptr_t vmm_unmap_pages_in(uint64_t *pml4, uintptr_t virt_addr,
+                                    size_t num_pages) {
+    const uint64_t lock_flags = spinlock_lock_irqsave(&vmm_map_lock);
+    const uintptr_t result = nolock_vmm_unmap_page_in(pml4, virt_addr);
+
+    for (int i = 1; i < num_pages; i++) {
+        nolock_vmm_unmap_page_in(pml4, virt_addr + (i << VM_PAGE_LINEAR_SHIFT));
+    }
+
+    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
+    return result;
+}
+
+inline uintptr_t vmm_unmap_page_in(uint64_t *pml4, uintptr_t virt_addr) {
+    const uint64_t lock_flags = spinlock_lock_irqsave(&vmm_map_lock);
+    const uintptr_t result = nolock_vmm_unmap_page_in(pml4, virt_addr);
+    spinlock_unlock_irqrestore(&vmm_map_lock, lock_flags);
+    return result;
+}
+
+uintptr_t vmm_unmap_pages(const uintptr_t virt_addr, size_t num_pages) {
+    return vmm_unmap_pages_in(
+            vmm_phys_to_virt_ptr(cpu_satp_to_root_table_phys(cpu_read_satp())),
+            virt_addr, num_pages);
+}
+
+uintptr_t vmm_unmap_page(const uintptr_t virt_addr) {
     return vmm_unmap_page_in(
             vmm_phys_to_virt_ptr(cpu_satp_to_root_table_phys(cpu_read_satp())),
             virt_addr);

--- a/kernel/include/smp/ipwi.h
+++ b/kernel/include/smp/ipwi.h
@@ -61,8 +61,9 @@ typedef struct {
     uint64_t reserved0;
     uintptr_t start_vaddr;
     size_t page_count;
-    uint64_t target_pid;
-    uint64_t reserved1[3];
+    uint64_t target_pid;   // Only PID, **or** PML4,
+    uintptr_t target_pml4; // never both!
+    uint64_t reserved1[2];
 } IpwiPayloadTLBShootdown;
 
 typedef struct {

--- a/kernel/include/vmm/shootdown.h
+++ b/kernel/include/vmm/shootdown.h
@@ -1,0 +1,92 @@
+/*
+ * stage3 - TLB shootdown wrapper for VMM
+ * anos - An Operating System
+ *
+ * Copyright (c) 2025 Ross Bamford
+ *
+ * This is essentially a thin wrapper over the vmm_map/unmap_page
+ * API that performs TLB shootdowns.
+ *
+ * Shootdowns are **expensive**! Only use these routines when
+ * it's actually necessary, use the lower-level functions
+ * directly if at all possible.
+ */
+
+#ifndef __ANOS_KERNEL_VM_SHOOTDOWN_H
+#define __ANOS_KERNEL_VM_SHOOTDOWN_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "process.h"
+
+bool vmm_shootdown_map_page_containing_in_process(const Process *process,
+                                                  uintptr_t virt_addr,
+                                                  uintptr_t phys_addr,
+                                                  uintptr_t flags);
+
+bool vmm_shootdown_map_page_containing_in_pml4(uint64_t *pml4_virt,
+                                               uintptr_t virt_addr,
+                                               uintptr_t phys_addr,
+                                               uintptr_t flags);
+
+bool vmm_shootdown_map_pages_containing_in_process(const Process *process,
+                                                   uintptr_t virt_addr,
+                                                   uintptr_t phys_addr,
+                                                   uintptr_t flags,
+                                                   size_t num_pages);
+
+bool vmm_shootdown_map_pages_containing_in_pml4(uint64_t *pml4_virt,
+                                                uintptr_t virt_addr,
+                                                uintptr_t phys_addr,
+                                                uintptr_t flags,
+                                                size_t num_pages);
+
+bool vmm_shootdown_map_page_containing(uintptr_t virt_addr, uintptr_t phys_addr,
+                                       uintptr_t flags);
+
+bool vmm_shootdown_map_page_in_process(const Process *process,
+                                       uintptr_t virt_addr, uintptr_t page,
+                                       uintptr_t flags);
+
+bool vmm_shootdown_map_page_in_pml4(uint64_t *pml4_virt, uintptr_t virt_addr,
+                                    uintptr_t page, uintptr_t flags);
+
+bool vmm_shootdown_map_page(uintptr_t virt_addr, uintptr_t page,
+                            uintptr_t flags);
+
+bool vmm_shootdown_map_pages_containing(uintptr_t virt_addr,
+                                        uintptr_t phys_addr, uintptr_t flags,
+                                        size_t num_pages);
+
+bool vmm_shootdown_map_pages_in_process(const Process *process,
+                                        uintptr_t virt_addr, uintptr_t page,
+                                        uintptr_t flags, size_t num_pages);
+
+bool vmm_shootdown_map_pages_in_pml4(uint64_t *pml4_virt, uintptr_t virt_addr,
+                                     uintptr_t page, uintptr_t flags,
+                                     size_t num_pages);
+
+bool vmm_shootdown_map_pages(uintptr_t virt_addr, uintptr_t page,
+                             uintptr_t flags, size_t num_pages);
+
+uintptr_t vmm_shootdown_unmap_page_in_process(const Process *process,
+                                              uintptr_t virt_addr);
+
+uintptr_t vmm_shootdown_unmap_page_in_pml4(uint64_t *pml4_virt,
+                                           uintptr_t virt_addr);
+
+uintptr_t vmm_shootdown_unmap_page(uintptr_t virt_addr);
+
+uintptr_t vmm_shootdown_unmap_pages_in_process(const Process *process,
+                                               uintptr_t virt_addr,
+                                               size_t num_pages);
+
+uintptr_t vmm_shootdown_unmap_pages_in_pml4(uint64_t *pml4_virt,
+                                            uintptr_t virt_addr,
+                                            size_t num_pages);
+
+uintptr_t vmm_shootdown_unmap_pages(uintptr_t virt_addr, size_t num_pages);
+
+#endif //__ANOS_KERNEL_VM_SHOOTDOWN_H

--- a/kernel/tests/include.mk
+++ b/kernel/tests/include.mk
@@ -298,6 +298,9 @@ kernel/tests/build/structs/region_tree: kernel/tests/munit.o kernel/tests/struct
 kernel/tests/build/smp/ipwi: kernel/tests/munit.o kernel/tests/smp/ipwi.o kernel/tests/build/smp/ipwi.o
 	$(CC) $(KERNEL_TEST_CFLAGS) -o $@ $^
 
+kernel/tests/build/vmm/vmm_shootdown: kernel/tests/munit.o kernel/tests/vmm/vmm_shootdown.o kernel/tests/build/vmm/vmm_shootdown.o
+	$(CC) $(KERNEL_TEST_CFLAGS) -o $@ $^
+
 kernel/tests/build/arch/x86_64/spinlock: kernel/tests/munit.o kernel/tests/arch/x86_64/spinlock.o kernel/tests/build/arch/x86_64/spinlock.o
 	$(CC) $(KERNEL_TEST_CFLAGS) -o $@ $^
 
@@ -366,7 +369,8 @@ ALL_TESTS=kernel/tests/build/interrupts 										\
 			kernel/tests/build/capabilities/map									\
 			kernel/tests/build/managed_resources/resources						\
 			kernel/tests/build/structs/region_tree								\
-			kernel/tests/build/smp/ipwi
+			kernel/tests/build/smp/ipwi											\
+			kernel/tests/build/vmm/vmm_shootdown
 
 ifeq ($(HOST_ARCH),i386)	# macOS
 ALL_TESTS+=	kernel/tests/build/arch/x86_64/spinlock								\

--- a/kernel/tests/process/process.c
+++ b/kernel/tests/process/process.c
@@ -229,6 +229,7 @@ test_remove_nonexistent_resource(const MunitParameter params[], void *data) {
 
 void *setup(const MunitParameter params[], void *user_data) {
     mock_slab_reset();
+    return NULL;
 }
 
 static MunitTest tests[] = {

--- a/kernel/tests/vmm/vmm_shootdown.c
+++ b/kernel/tests/vmm/vmm_shootdown.c
@@ -1,0 +1,241 @@
+/*
+ * Tests for virtual memory TLB shootdown
+ * anos - An Operating System
+ *
+ * Copyright (c) 2024 Ross Bamford
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "munit.h"
+
+#include "process.h"
+#include "smp/ipwi.h"
+#include "task.h"
+#include "vmm/shootdown.h"
+
+#include "mock_pagetables.h"
+
+// === Mocks & flags for verification ===
+static bool mock_map_called = false;
+static bool mock_unmap_called = false;
+static bool ipi_enqueued = false;
+static uintptr_t last_virt_addr = 0;
+static uintptr_t last_phys_addr = 0;
+static uintptr_t last_flags = 0;
+static size_t last_page_count = 0;
+static uintptr_t last_target_pml4 = 0;
+
+static uintptr_t last_ipwi_virt_addr = 0;
+static size_t last_ipwi_page_count = 0;
+static uint64_t last_ipwi_target_pid = 0;
+static uintptr_t last_ipwi_target_pml4 = 0;
+
+bool vmm_map_page_containing_in(uint64_t *pml4, uintptr_t v, uint64_t p,
+                                uint16_t f) {
+    mock_map_called = true;
+    last_virt_addr = v;
+    last_phys_addr = p;
+    last_flags = f;
+    last_page_count = 1;
+    last_target_pml4 = (uintptr_t)pml4;
+
+    return true;
+}
+
+bool vmm_map_pages_containing_in(uint64_t *pml4, uintptr_t v, uint64_t p,
+                                 uint16_t f, size_t n) {
+    mock_map_called = true;
+    last_virt_addr = v;
+    last_phys_addr = p;
+    last_flags = f;
+    last_page_count = n;
+    last_target_pml4 = (uintptr_t)pml4;
+
+    return true;
+}
+
+uintptr_t vmm_unmap_page_in(uint64_t *pml4, const uintptr_t v) {
+    mock_unmap_called = true;
+    last_virt_addr = v;
+    last_page_count = 1;
+    last_target_pml4 = (uintptr_t)pml4;
+
+    return 0xDEADBEEF;
+}
+
+uintptr_t vmm_unmap_pages_in(uint64_t *pml4, const uintptr_t v,
+                             const size_t n) {
+    mock_unmap_called = true;
+    last_virt_addr = v;
+    last_page_count = n;
+    last_target_pml4 = (uintptr_t)pml4;
+
+    return 0xDEADBEEF + n;
+}
+
+uintptr_t vmm_virt_to_phys(const uintptr_t virt_addr) {
+    return virt_addr ^ 0x12340000;
+}
+
+void *vmm_phys_to_virt_ptr(const uintptr_t phys_addr) {
+    return (void *)(phys_addr | 0x12340000);
+}
+
+bool ipwi_enqueue_all_except_current(IpwiWorkItem *item) {
+    ipi_enqueued = true;
+    const IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&item->payload;
+
+    last_ipwi_page_count = payload->page_count;
+    last_ipwi_virt_addr = payload->start_vaddr;
+    last_ipwi_target_pid = payload->target_pid;
+    last_ipwi_target_pml4 = payload->target_pml4;
+
+    return true;
+}
+
+static Process fake_proc = {
+        .pid = 42,
+        .pml4 = (uintptr_t)0xCAFEB000,
+};
+
+static Task dummy_task = {
+        .owner = &fake_proc,
+};
+
+Task *task_current(void) { return &dummy_task; }
+
+uint64_t save_disable_interrupts(void) { return 0x1983; }
+void restore_saved_interrupts(const uint64_t flags) { (void)flags; }
+
+// === TESTS ===
+
+#define RESET_FLAGS()                                                          \
+    do {                                                                       \
+        mock_map_called = false;                                               \
+        mock_unmap_called = false;                                             \
+        ipi_enqueued = false;                                                  \
+        last_virt_addr = last_phys_addr = last_flags = 0;                      \
+        last_page_count = last_target_pml4 = 0;                                \
+        last_ipwi_page_count = 0;                                              \
+        last_ipwi_target_pid = 0;                                              \
+        last_ipwi_target_pml4 = 0;                                             \
+        last_ipwi_virt_addr = 0;                                               \
+    } while (0)
+
+static MunitResult test_map_page_process(const MunitParameter params[],
+                                         void *data) {
+    RESET_FLAGS();
+    const bool result = vmm_shootdown_map_page_containing_in_process(
+            &fake_proc, 0x4000, 0x9000, 0x07);
+
+    munit_assert_true(result);
+    munit_assert_true(mock_map_called && ipi_enqueued);
+    munit_assert_uint64(last_virt_addr, ==, 0x4000);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_unmap_page_process(const MunitParameter params[],
+                                           void *data) {
+    RESET_FLAGS();
+    const uintptr_t r = vmm_shootdown_unmap_page_in_process(&fake_proc, 0xC000);
+
+    munit_assert_true(mock_unmap_called && ipi_enqueued);
+    munit_assert_uint64(last_virt_addr, ==, 0xC000);
+    munit_assert_uint64(r, ==, 0xDEADBEEF);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_map_pages_pml4(const MunitParameter params[],
+                                       void *data) {
+    RESET_FLAGS();
+    uint64_t *pml4 = (uint64_t *)0x88888000;
+    const bool result = vmm_shootdown_map_pages_containing_in_pml4(
+            pml4, 0x7000, 0x1234, 0x05, 3);
+
+    munit_assert_true(result);
+    munit_assert_true(mock_map_called && ipi_enqueued);
+    munit_assert_uint64(last_page_count, ==, 3);
+    munit_assert_uint64(last_target_pml4, ==, (uintptr_t)pml4);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_unmap_pages_current(const MunitParameter params[],
+                                            void *data) {
+    RESET_FLAGS();
+    const uintptr_t r = vmm_shootdown_unmap_pages(0x9000, 2);
+
+    munit_assert_true(mock_unmap_called && ipi_enqueued);
+    munit_assert_uint64(last_page_count, ==, 2);
+    munit_assert_uint64(r, ==, 0xDEADBEEF + 2);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_alias_map_page(const MunitParameter params[],
+                                       void *data) {
+    RESET_FLAGS();
+    const bool result = vmm_shootdown_map_page(0x5000, 0x6000, 0x01);
+
+    munit_assert_true(result);
+    munit_assert_true(mock_map_called && ipi_enqueued);
+    munit_assert_uint64(last_virt_addr, ==, 0x5000);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_alias_map_pages(const MunitParameter params[],
+                                        void *data) {
+    RESET_FLAGS();
+    const bool result = vmm_shootdown_map_pages(0xD000, 0xE000, 0x03, 4);
+
+    munit_assert_true(result);
+    munit_assert_true(mock_map_called && ipi_enqueued);
+    munit_assert_uint64(last_virt_addr, ==, 0xD000);
+    munit_assert_uint64(last_page_count, ==, 4);
+
+    return MUNIT_OK;
+}
+
+static MunitResult test_alias_unmap_page(const MunitParameter params[],
+                                         void *data) {
+    RESET_FLAGS();
+    const uintptr_t r = vmm_shootdown_unmap_page(0xA000);
+
+    munit_assert_true(mock_unmap_called && ipi_enqueued);
+    munit_assert_uint64(last_virt_addr, ==, 0xA000);
+    munit_assert_uint64(r, ==, 0xDEADBEEF);
+
+    return MUNIT_OK;
+}
+
+static MunitTest shootdown_tests[] = {
+        {"/map_page_process", test_map_page_process, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {"/unmap_page_process", test_unmap_page_process, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {"/map_pages_pml4", test_map_pages_pml4, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {"/unmap_pages_current", test_unmap_pages_current, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {"/alias_map_page", test_alias_map_page, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {"/alias_map_pages", test_alias_map_pages, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {"/alias_unmap_page", test_alias_unmap_page, NULL, NULL,
+         MUNIT_TEST_OPTION_NONE, NULL},
+        {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL}};
+
+static const MunitSuite shootdown_suite = {"/vmm/shootdown", shootdown_tests,
+                                           NULL, 1, MUNIT_SUITE_OPTION_NONE};
+
+int main(const int argc, char *argv[]) {
+    return munit_suite_main(&shootdown_suite, NULL, argc, argv);
+}

--- a/kernel/vmm/vmm_shootdown.c
+++ b/kernel/vmm/vmm_shootdown.c
@@ -1,0 +1,335 @@
+/*
+ * stage3 - TLB shootdown
+ * anos - An Operating System
+ *
+ * Copyright (c) 2025 Ross Bamford
+ *
+ * This is essentially a thin wrapper over the vmm_map/unmap_page
+ * API that performs TLB shootdowns.
+ *
+ * Shootdowns are **expensive**! Only use these routines when
+ * it's actually necessary, use the lower-level functions
+ * directly if at all possible.
+ */
+
+#include "process.h"
+#include "smp/ipwi.h"
+#include "task.h"
+#include "vmm/vmmapper.h"
+
+bool vmm_shootdown_map_page_containing_in_process(const Process *process,
+                                                  const uintptr_t virt_addr,
+                                                  const uintptr_t phys_addr,
+                                                  const uintptr_t flags) {
+    // This is **incredibly slow** on x86_64, so do it before
+    // disabling interrupts...
+    //
+    // TODO this actually **cannot** work on x86_64 currently, phys_to_virt
+    //      only works within the current address space due to recursive paging!
+    void *pml4_virt = vmm_phys_to_virt_ptr(process->pml4);
+
+    if (!pml4_virt) {
+        return false;
+    }
+
+    const uint64_t intr_flags = save_disable_interrupts();
+
+    const uintptr_t result =
+            vmm_map_page_containing_in(pml4_virt, virt_addr, phys_addr, flags);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = process->pid;
+    payload->target_pml4 = 0;
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(intr_flags);
+
+    return result;
+}
+
+bool vmm_shootdown_map_page_containing_in_pml4(uint64_t *pml4_virt,
+                                               uintptr_t virt_addr,
+                                               const uintptr_t phys_addr,
+                                               const uintptr_t flags) {
+    const uint64_t intr_flags = save_disable_interrupts();
+
+    const uintptr_t result =
+            vmm_map_page_containing_in(pml4_virt, virt_addr, phys_addr, flags);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = 0;
+    payload->target_pml4 = vmm_virt_to_phys((uintptr_t)pml4_virt);
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(intr_flags);
+
+    return result;
+}
+
+bool vmm_shootdown_map_pages_containing_in_process(const Process *process,
+                                                   const uintptr_t virt_addr,
+                                                   const uintptr_t phys_addr,
+                                                   const uintptr_t flags,
+                                                   const size_t num_pages) {
+    // This is **incredibly slow** on x86_64, so do it before
+    // disabling interrupts...
+    void *pml4_virt = vmm_phys_to_virt_ptr(process->pml4);
+
+    if (!pml4_virt) {
+        return false;
+    }
+
+    const uint64_t intr_flags = save_disable_interrupts();
+
+    const uintptr_t result = vmm_map_pages_containing_in(
+            pml4_virt, virt_addr, phys_addr, flags, num_pages);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = process->pid;
+    payload->target_pml4 = 0;
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(intr_flags);
+
+    return result;
+}
+
+bool vmm_shootdown_map_pages_containing_in_pml4(uint64_t *pml4_virt,
+                                                const uintptr_t virt_addr,
+                                                const uintptr_t phys_addr,
+                                                const uintptr_t flags,
+                                                const size_t num_pages) {
+    const uint64_t intr_flags = save_disable_interrupts();
+
+    const uintptr_t result = vmm_map_pages_containing_in(
+            pml4_virt, virt_addr, phys_addr, flags, num_pages);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = 0;
+    payload->target_pml4 = vmm_virt_to_phys((uintptr_t)pml4_virt);
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(intr_flags);
+
+    return result;
+}
+
+bool vmm_shootdown_map_page_containing(const uintptr_t virt_addr,
+                                       const uintptr_t phys_addr,
+                                       const uintptr_t flags) {
+    return vmm_shootdown_map_page_containing_in_process(
+            task_current()->owner, virt_addr, phys_addr, flags);
+}
+
+bool vmm_shootdown_map_page_in_process(const Process *process,
+                                       const uintptr_t virt_addr,
+                                       const uintptr_t page,
+                                       const uintptr_t flags) {
+    return vmm_shootdown_map_page_containing_in_process(process, virt_addr,
+                                                        page, flags);
+}
+
+bool vmm_shootdown_map_page_in_pml4(uint64_t *pml4_virt,
+                                    const uintptr_t virt_addr,
+                                    const uintptr_t page,
+                                    const uintptr_t flags) {
+    return vmm_shootdown_map_page_containing_in_pml4(pml4_virt, virt_addr, page,
+                                                     flags);
+}
+
+bool vmm_shootdown_map_page(const uintptr_t virt_addr, const uintptr_t page,
+                            const uintptr_t flags) {
+    return vmm_shootdown_map_page_containing_in_process(task_current()->owner,
+                                                        virt_addr, page, flags);
+}
+
+uintptr_t vmm_shootdown_unmap_page_in_process(const Process *process,
+                                              const uintptr_t virt_addr) {
+    // This is **incredibly slow** on x86_64, so do it before
+    // disabling interrupts...
+    void *pml4_virt = vmm_phys_to_virt_ptr(process->pml4);
+
+    if (!pml4_virt) {
+        return false;
+    }
+
+    const uint64_t flags = save_disable_interrupts();
+
+    const uintptr_t result = vmm_unmap_page_in(pml4_virt, virt_addr);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = process->pid;
+    payload->target_pml4 = 0;
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(flags);
+
+    return result;
+}
+
+uintptr_t vmm_shootdown_unmap_page_in_pml4(uint64_t *pml4_virt,
+                                           const uintptr_t virt_addr) {
+    const uint64_t flags = save_disable_interrupts();
+
+    const uintptr_t result = vmm_unmap_page_in(pml4_virt, virt_addr);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = 0;
+    payload->target_pml4 = vmm_virt_to_phys((uintptr_t)pml4_virt);
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(flags);
+
+    return result;
+}
+
+uintptr_t vmm_shootdown_unmap_page(const uintptr_t virt_addr) {
+    return vmm_shootdown_unmap_page_in_process(task_current()->owner,
+                                               virt_addr);
+}
+
+bool vmm_shootdown_map_pages_containing(const uintptr_t virt_addr,
+                                        const uintptr_t phys_addr,
+                                        const uintptr_t flags,
+                                        const size_t num_pages) {
+    return vmm_shootdown_map_pages_containing_in_process(
+            task_current()->owner, virt_addr, phys_addr, flags, num_pages);
+}
+
+bool vmm_shootdown_map_pages_in_process(const Process *process,
+                                        const uintptr_t virt_addr,
+                                        const uintptr_t page,
+                                        const uintptr_t flags,
+                                        const size_t num_pages) {
+    return vmm_shootdown_map_pages_containing_in_process(
+            process, virt_addr, page, flags, num_pages);
+}
+
+bool vmm_shootdown_map_pages_in_pml4(uint64_t *pml4_virt,
+                                     const uintptr_t virt_addr,
+                                     const uintptr_t page,
+                                     const uintptr_t flags,
+                                     const size_t num_pages) {
+    return vmm_shootdown_map_pages_containing_in_pml4(pml4_virt, virt_addr,
+                                                      page, flags, num_pages);
+}
+
+bool vmm_shootdown_map_pages(const uintptr_t virt_addr, const uintptr_t page,
+                             const uintptr_t flags, const size_t num_pages) {
+    return vmm_shootdown_map_pages_containing_in_process(
+            task_current()->owner, virt_addr, page, flags, num_pages);
+}
+
+uintptr_t vmm_shootdown_unmap_pages_in_process(const Process *process,
+                                               const uintptr_t virt_addr,
+                                               const size_t num_pages) {
+    // This is **incredibly slow** on x86_64, so do it before
+    // disabling interrupts...
+    void *pml4_virt = vmm_phys_to_virt_ptr(process->pml4);
+
+    if (!pml4_virt) {
+        return false;
+    }
+
+    const uint64_t flags = save_disable_interrupts();
+
+    const uintptr_t result =
+            vmm_unmap_pages_in(pml4_virt, virt_addr, num_pages);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = process->pid;
+    payload->target_pml4 = 0;
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(flags);
+
+    return result;
+}
+
+uintptr_t vmm_shootdown_unmap_pages_in_pml4(uint64_t *pml4_virt,
+                                            const uintptr_t virt_addr,
+                                            const size_t num_pages) {
+    const uint64_t flags = save_disable_interrupts();
+
+    const uintptr_t result =
+            vmm_unmap_pages_in(pml4_virt, virt_addr, num_pages);
+
+    IpwiWorkItem work_item = {
+            .type = IPWI_TYPE_TLB_SHOOTDOWN,
+            .flags = 0,
+    };
+
+    IpwiPayloadTLBShootdown *payload =
+            (IpwiPayloadTLBShootdown *)&work_item.payload;
+    payload->page_count = 1;
+    payload->start_vaddr = virt_addr;
+    payload->target_pid = 0;
+    payload->target_pml4 = vmm_virt_to_phys((uintptr_t)pml4_virt);
+
+    ipwi_enqueue_all_except_current(&work_item);
+    restore_saved_interrupts(flags);
+
+    return result;
+}
+
+uintptr_t vmm_shootdown_unmap_pages(const uintptr_t virt_addr,
+                                    const size_t num_pages) {
+    return vmm_shootdown_unmap_pages_in_process(task_current()->owner,
+                                                virt_addr, num_pages);
+}


### PR DESCRIPTION
Adding TLB shootdown support via IPIs.

This is currently paused as it's pushed us past the point where recursive paging makes sense, so this won't go in until x86_64 is switched to direct mapping (riscv64 is already there).