### PR TITLE
Feature/move local apic to device space

### DIFF
--- a/kernel/arch/x86_64/include/x86_64/kdrivers/local_apic.h
+++ b/kernel/arch/x86_64/include/x86_64/kdrivers/local_apic.h
@@ -18,8 +18,8 @@
 // This doesn't belong here, it'll go away when we go tickless...
 #define KERNEL_HZ ((100))
 
-#define REG_LAPIC_ID_O 0x04
-#define REG_LAPIC_VERSION_O 0x08
+#define REG_LAPIC_ID_O 0x08
+#define REG_LAPIC_VERSION_O 0x0c
 #define REG_LAPIC_EOI_O 0x2c
 #define REG_LAPIC_SPURIOUS_O 0x3c
 #define REG_LAPIC_DIVIDE_O 0xf8

--- a/kernel/arch/x86_64/include/x86_64/vmm/vmmapper.h
+++ b/kernel/arch/x86_64/include/x86_64/vmm/vmmapper.h
@@ -139,6 +139,6 @@ size_t vmm_level_page_size(const uint8_t level);
 // Initialize the direct mapping for physical memory
 // This must be called during early boot, before SMP
 // or userspace is up (since it abuses both those things)
-void vmm_init_direct_mapping(uint64_t *pml4, Limine_MemMap *memmap);
+void vmm_init_direct_mapping(uint64_t *pml4, const Limine_MemMap *memmap);
 
 #endif //__ANOS_KERNEL_ARCH_X86_64_VM_MAPPER_H

--- a/kernel/arch/x86_64/kdrivers/local_apic.c
+++ b/kernel/arch/x86_64/kdrivers/local_apic.c
@@ -30,7 +30,7 @@ static void start_timer(uint32_t volatile *lapic, uint8_t mode,
 
 static uint64_t local_apic_calibrate_count(const KernelTimer *calibrated_timer,
                                            const uint32_t desired_hz) {
-    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_BASE);
+    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_LAPIC);
 
     const uint64_t calibrated_ticks_20ms =
             NANOS_IN_20MS / calibrated_timer->nanos_per_tick();
@@ -65,16 +65,16 @@ uint32_t volatile *init_local_apic(ACPI_MADT *madt, bool bsp) {
     uint32_t lapic_addr = madt->lapic_address;
 #ifdef DEBUG_LAPIC_INIT
     uint32_t *flags = (uint32_t *)((uintptr_t)lapic_addr) + 1;
-    kprintf("LAPIC address (phys : virt) = 0x%08x : 0xffffffa000000000\n",
-            lapic_addr);
+    kprintf("LAPIC address (phys : virt) = 0x%08x : 0x%016lx\n", lapic_addr,
+            KERNEL_HARDWARE_VADDR_LAPIC);
 #endif
 
     if (bsp) {
-        vmm_map_page(KERNEL_HARDWARE_VADDR_BASE, lapic_addr,
+        vmm_map_page(KERNEL_HARDWARE_VADDR_LAPIC, lapic_addr,
                      PG_PRESENT | PG_WRITE);
     }
 
-    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_BASE);
+    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_LAPIC);
 
 #ifdef DEBUG_LAPIC_INIT
     kprintf("LAPIC ID: 0x%08x; Version: 0x%08x\n", *REG_LAPIC_ID(lapic),
@@ -105,11 +105,11 @@ uint32_t volatile *init_local_apic(ACPI_MADT *madt, bool bsp) {
 }
 
 uint64_t local_apic_get_count(void) {
-    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_BASE);
+    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_LAPIC);
     return *REG_LAPIC_CURRENT_COUNT(lapic);
 }
 
 void local_apic_eoe(void) {
-    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_BASE);
+    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_LAPIC);
     *(REG_LAPIC_EOI(lapic)) = 0;
 }

--- a/kernel/arch/x86_64/smp/ipwi.c
+++ b/kernel/arch/x86_64/smp/ipwi.c
@@ -12,7 +12,7 @@ void arch_ipwi_notify_all_except_current(void) {
     // TODO using ALL_EXCLUDING_SELF is probably a bad idea here,
     //      what if we didn't spin up all APs properly?
     //
-    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_BASE);
+    uint32_t volatile *lapic = (uint32_t *)(KERNEL_HARDWARE_VADDR_LAPIC);
 
     while (*(REG_LAPIC_ICR_LOW(lapic)) & LAPIC_ICR_DELIVERY_STATUS)
         ;

--- a/kernel/arch/x86_64/vmm/vmmapper_init.c
+++ b/kernel/arch/x86_64/vmm/vmmapper_init.c
@@ -618,9 +618,9 @@ static void cleanup_temp_page_tables(uint64_t *const pml4) {
  *
  * Other than that, it's all much of a muchness.
  */
-void vmm_init_direct_mapping(uint64_t *pml4_virt, Limine_MemMap *memmap) {
+void vmm_init_direct_mapping(uint64_t *pml4_virt, const Limine_MemMap *memmap) {
     vdebugf("vmm_init_direct_mapping: init with %ld entries at pml4 0x%016lx\n",
-            memmap->entry_count, (uintptr_t)pml4);
+            memmap->entry_count, (uintptr_t)pml4_virt);
 
     const uintptr_t temp_pdpt_phys = (uintptr_t)temp_pdpt - STATIC_KERNEL_SPACE;
     const uintptr_t saved_pml4_0 = pml4_virt[0];

--- a/kernel/include/kdrivers/drivers.h
+++ b/kernel/include/kdrivers/drivers.h
@@ -22,8 +22,8 @@
 #include "platform/acpi/acpitables.h"
 
 // See MemoryMap.md for details on the size and purpose of these...
-#define KERNEL_HARDWARE_VADDR_BASE 0xffffffa000000000
-#define KERNEL_DRIVER_VADDR_BASE 0xffffffff81020000
+#define KERNEL_HARDWARE_VADDR_LAPIC 0xffffffff81020000
+#define KERNEL_DRIVER_VADDR_BASE ((KERNEL_HARDWARE_VADDR_LAPIC + 0x1000))
 #define KERNEL_DRIVER_VADDR_SIZE 0x00000000000e0000
 
 typedef uint64_t (*KDriverEntrypoint)(void *arg);


### PR DESCRIPTION
This has been a TODO for a while, handling now before we start on new memory map for RISC-V SV39 targets.