### PR TITLE
Fix stack traces on x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ STAGE3_OBJS_X86_64= $(STAGE3_DIR)/platform/acpi/acpitables.o					\
 					$(STAGE3_ARCH_X86_64_DIR)/interrupts.o						\
 					$(STAGE3_ARCH_X86_64_DIR)/isr_dispatch.o					\
 					$(STAGE3_ARCH_X86_64_DIR)/init_interrupts.o					\
+					$(STAGE3_ARCH_X86_64_DIR)/isr_handlers.o					\
 					$(STAGE3_ARCH_X86_64_DIR)/pagefault.o						\
 					$(STAGE3_ARCH_X86_64_DIR)/init_pagetables.o					\
 					$(STAGE3_ARCH_X86_64_DIR)/vmm/vmmapper.o					\
@@ -279,7 +280,6 @@ STAGE3_OBJS=$(STAGE3_DIR)/entrypoint.o											\
 			$(STAGE3_DIR)/banner.o												\
 			$(STAGE3_DIR)/debugmemmap.o											\
 			$(STAGE3_DIR)/kprintf.o												\
-			$(STAGE3_DIR)/isr_handlers.o										\
 			$(STAGE3_DIR)/pmm/pagealloc.o										\
 			$(STAGE3_DIR)/fba/alloc.o											\
 			$(STAGE3_DIR)/slab/alloc.o											\
@@ -492,7 +492,7 @@ $(STAGE3_DIR)/$(STAGE3).dis: $(STAGE3_DIR)/$(STAGE3).elf
 
 
 # ############ UEFI Image ############
-UEFI_IMG=anos_uefi.img
+UEFI_IMG=image.img
 UEFI_BOOT_WALLPAPER?=uefi/anoschip2-glass.jpg
 UEFI_CONF?=uefi/$(ARCH)/limine.conf
 

--- a/kernel/arch/riscv64/include/riscv64/isr_frame.h
+++ b/kernel/arch/riscv64/include/riscv64/isr_frame.h
@@ -1,0 +1,73 @@
+/*
+ * stage3 - ISR stack frame (riscv64)
+ * anos - An Operating System
+ *
+ * Copyright (c) 2025 Ross Bamford
+ */
+
+// clang-format Language: C
+
+#ifndef __ANOS_KERNEL_ARCH_X86_64_ISR_FRAME_H
+#define __ANOS_KERNEL_ARCH_X86_64_ISR_FRAME_H
+
+#include <stdint.h>
+
+/*
+ * N.B. This must be kept in-step with the _trap_dispatcher_impl macro in isr_dispatch.S
+ */
+typedef struct {
+    uintptr_t ft11;
+    uintptr_t ft10;
+    uintptr_t ft9;
+    uintptr_t ft8;
+    uintptr_t fa7;
+    uintptr_t fa6;
+    uintptr_t fa5;
+    uintptr_t fa4;
+    uintptr_t fa3;
+    uintptr_t fa2;
+    uintptr_t fa1;
+    uintptr_t fa0;
+    uintptr_t ft7;
+    uintptr_t ft6;
+    uintptr_t ft5;
+    uintptr_t ft4;
+    uintptr_t ft3;
+    uintptr_t ft2;
+    uintptr_t ft1;
+    uintptr_t ft0;
+    uintptr_t res;
+    uintptr_t t6;
+    uintptr_t t5;
+    uintptr_t t4;
+    uintptr_t t3;
+    uintptr_t a7;
+    uintptr_t a6;
+    uintptr_t a5;
+    uintptr_t a4;
+    uintptr_t a3;
+    uintptr_t a2;
+    uintptr_t a1;
+    uintptr_t a0;
+    uintptr_t t2;
+    uintptr_t t1;
+    uintptr_t fcsr;
+    uintptr_t t0;
+    uintptr_t ra;
+    uintptr_t tp;
+    uintptr_t rbp; // NOTE: Not actually a base pointer on RISC-V! Actually just a reserved stack slot...
+} Registers;
+
+typedef struct {
+    Registers registers;
+
+    // TODO code/no-code is probably useless on RISC-V...
+} IsrStackFrameNoCode;
+
+typedef struct {
+    Registers registers;
+
+    // TODO code/no-code is probably useless on RISC-V...
+} IsrStackFrameWithCode;
+
+#endif

--- a/kernel/arch/riscv64/isr_dispatch.S
+++ b/kernel/arch/riscv64/isr_dispatch.S
@@ -116,6 +116,7 @@ handle_page_fault_write_\idx:
 handle_page_fault_\idx:
     csrr    a1, stval       # a1 = fault address
     csrr    a2, sepc        # a2 = origin address
+    mv      a3, sp          # a3 = pointer to regs (top of stack)
 
     call    page_fault_wrapper
 

--- a/kernel/arch/riscv64/pagefault.c
+++ b/kernel/arch/riscv64/pagefault.c
@@ -5,16 +5,20 @@
  * Copyright (c) 2023 Ross Bamford
  */
 
-#include "pagefault.h"
+#include <stdint.h>
+
+#include "isr_frame.h"
 #include "machine.h"
+#include "pagefault.h"
 
 static bool smp_started;
 
-void page_fault_wrapper(const uint64_t code, const uint64_t fault_addr, const uint64_t origin_addr) {
+void page_fault_wrapper(const uint64_t code, const uint64_t fault_addr, const uint64_t origin_addr,
+                        IsrStackFrameWithCode *stack_frame) {
     if (likely(smp_started)) {
-        page_fault_handler(code, fault_addr, origin_addr);
+        page_fault_handler(code, fault_addr, origin_addr, stack_frame);
     } else {
-        early_page_fault_handler(code, fault_addr, origin_addr);
+        early_page_fault_handler(code, fault_addr, origin_addr, stack_frame);
     }
 }
 

--- a/kernel/arch/x86_64/general_protection_fault.c
+++ b/kernel/arch/x86_64/general_protection_fault.c
@@ -7,8 +7,10 @@
 
 #include <stdint.h>
 
+#include "isr_frame.h"
 #include "panic.h"
 
-void handle_general_protection_fault(const uint64_t code, const uintptr_t origin_addr) {
-    panic_general_protection_fault(code, origin_addr);
+void handle_general_protection_fault(const uint64_t code, const uintptr_t origin_addr,
+                                     const IsrStackFrameWithCode *stack_frame) {
+    panic_general_protection_fault(code, origin_addr, stack_frame->registers.rbp);
 }

--- a/kernel/arch/x86_64/include/x86_64/general_protection_fault.h
+++ b/kernel/arch/x86_64/include/x86_64/general_protection_fault.h
@@ -12,6 +12,6 @@
 
 #include <stdint.h>
 
-void handle_general_protection_fault(uint64_t code, uintptr_t origin_addr);
+void handle_general_protection_fault(uint64_t code, uintptr_t origin_addr, const IsrStackFrameWithCode *stack_frame);
 
 #endif //__ANOS_KERNEL_ARCH_X86_64_GENERAL_PROTECTION_FAULT_H

--- a/kernel/arch/x86_64/include/x86_64/isr_frame.h
+++ b/kernel/arch/x86_64/include/x86_64/isr_frame.h
@@ -1,0 +1,48 @@
+/*
+ * stage3 - ISR stack frame (x86_64)
+ * anos - An Operating System
+ *
+ * Copyright (c) 2025 Ross Bamford
+ */
+
+// clang-format Language: C
+
+#ifndef __ANOS_KERNEL_ARCH_X86_64_ISR_FRAME_H
+#define __ANOS_KERNEL_ARCH_X86_64_ISR_FRAME_H
+
+#include <stdint.h>
+
+/*
+ * N.B. This must be kept in-step with the pusha_sysv macros in isr_common!
+ */
+typedef struct {
+    uintptr_t rbp;
+    uintptr_t r11;
+    uintptr_t r10;
+    uintptr_t r9;
+    uintptr_t r8;
+    uintptr_t rdi;
+    uintptr_t rsi;
+    uintptr_t rdx;
+    uintptr_t rcx;
+    uintptr_t rax;
+} Registers;
+
+typedef struct {
+    Registers registers;
+    uintptr_t return_address;
+    uintptr_t cs;
+    uintptr_t rflags;
+    uintptr_t rsp;
+} IsrStackFrameNoCode;
+
+typedef struct {
+    Registers registers;
+    uintptr_t code;
+    uintptr_t return_address;
+    uintptr_t cs;
+    uintptr_t rflags;
+    uintptr_t rsp;
+} IsrStackFrameWithCode;
+
+#endif

--- a/kernel/arch/x86_64/isr_common.asm
+++ b/kernel/arch/x86_64/isr_common.asm
@@ -100,6 +100,7 @@ trap_dispatcher_%+%1:                       ; Name e.g. `trap_dispatcher_0`
     mov   rdi,%1                            ; Put the trap number in the first C argument
     mov   rsi,80[rsp]                       ; Error code from stack into the second C argument
     mov   rdx,88[rsp]                       ; Peek return address into third C argument
+    mov   rcx,rsp                           ; Pointer to stack in rcx, this becomes an IsrStackFrame struct
 
     ; Set up stack frame (so we can do sane backtrace)...
     call  .stack_frame_setup                ; push $rip first
@@ -128,6 +129,7 @@ trap_dispatcher_%+%1:                       ; Name e.g. `trap_dispatcher_1`
 
     mov   rdi,%1                            ; Put the trap number in the first C argument (TODO changing registers!)
     mov   rsi,80[rsp]                       ; Peek return address into second C argument
+    mov   rdx,rsp                           ; Pointer to stack in rdx, this becomes an IsrStackFrame struct
 
     ; Set up stack frame (so we can do sane backtrace)...
     call  .stack_frame_setup                ; push $rip first

--- a/kernel/arch/x86_64/isr_dispatch.asm
+++ b/kernel/arch/x86_64/isr_dispatch.asm
@@ -132,7 +132,8 @@ page_fault_dispatcher:
 
     mov   rdi,pusha_sysv_arg0[rsp]          ; Error code from stack into the first C argument
     mov   rsi,cr2                           ; Fault address into the second C argument
-    mov   rdx,pusha_sysv_arg1[rsp]                           ; Peek return address into third C argument
+    mov   rdx,pusha_sysv_arg1[rsp]          ; Peek return address into third C argument
+    mov   rcx,rsp                           ; Pointer to stack in rcx, this becomes an IsrStackFrame struct
 
     ; Set up stack frame (so we can do sane backtrace)...
     call  .stack_frame_setup                ; push $rip first

--- a/kernel/arch/x86_64/isr_handlers.c
+++ b/kernel/arch/x86_64/isr_handlers.c
@@ -1,35 +1,35 @@
 /*
- * stage3 - ISR handlers
+ * stage3 - ISR handlers for x86_64
  * anos - An Operating System
  *
  * Copyright (c) 2023 Ross Bamford
  */
-#include <stdbool.h>
+
 #include <stdint.h>
 
-#include "debugprint.h"
 #include "machine.h"
 #include "pagefault.h"
 #include "panic.h"
-#include "platform/acpi/acpitables.h"
-#include "printhex.h"
+
 #include "x86_64/general_protection_fault.h"
+#include "x86_64/isr_frame.h"
 
 /*
  * Actual handler for exceptions with no code.
  *
  * For now, just panics.
  */
-void handle_exception_nc(const uint8_t vector, const uint64_t origin_addr) {
-    panic_exception_no_code(vector, origin_addr);
+void handle_exception_nc(const uint8_t vector, const uint64_t origin_addr, IsrStackFrameNoCode *registers) {
+    panic_exception_no_code(vector, origin_addr, registers);
 }
 
 /*
  * Actual handler for exceptions with error code.
  *
- * For now, just panics.
+ * Handles very early #PF (which gets replaced after system is up) and also #GP (which just panics)
  */
-void handle_exception_wc(const uint8_t vector, const uint64_t code, const uint64_t origin_addr) {
+void handle_exception_wc(const uint8_t vector, const uint64_t code, const uint64_t origin_addr,
+                         IsrStackFrameWithCode *registers) {
     uint64_t fault_addr;
 
     switch (vector) {
@@ -38,13 +38,13 @@ void handle_exception_wc(const uint8_t vector, const uint64_t code, const uint64
         // This should only happen during early boot, we replace the
         // handler once tasking is up...
         __asm__ volatile("movq %%cr2,%0\n\t" : "=r"(fault_addr));
-        early_page_fault_handler(code, fault_addr, origin_addr);
+        early_page_fault_handler(code, fault_addr, origin_addr, registers);
         break;
     case 0x0d:
-        handle_general_protection_fault(code, origin_addr);
+        handle_general_protection_fault(code, origin_addr, registers);
         break;
     default:
-        panic_exception_with_code(vector, code, origin_addr);
+        panic_exception_with_code(vector, code, origin_addr, registers);
     }
 }
 

--- a/kernel/include/isr_frame.h
+++ b/kernel/include/isr_frame.h
@@ -1,0 +1,21 @@
+/*
+* stage3 - ISR stack frame (multi-arch)
+ * anos - An Operating System
+ *
+ * Copyright (c) 2025 Ross Bamford
+ */
+
+// clang-format Language: C
+
+#ifndef __ANOS_KERNEL_ISR_FRAME_H
+#define __ANOS_KERNEL_ISR_FRAME_H
+
+#ifdef ARCH_X86_64
+#include "x86_64/isr_frame.h"
+#elifdef ARCH_RISCV64
+#include "riscv64/isr_frame.h"
+#else
+#warning "Unsupported architecture in isr_frame.h"
+#endif
+
+#endif

--- a/kernel/include/pagefault.h
+++ b/kernel/include/pagefault.h
@@ -12,10 +12,14 @@
 
 #include <stdint.h>
 
+#include "isr_frame.h"
+
 void pagefault_notify_smp_started(void);
 
-void early_page_fault_handler(uint64_t code, uint64_t fault_addr, uint64_t origin_addr);
+void early_page_fault_handler(uint64_t code, uint64_t fault_addr, uint64_t origin_addr,
+                              IsrStackFrameWithCode *stack_frame);
 
-void page_fault_handler(uint64_t code, uintptr_t fault_addr, uintptr_t origin_addr);
+void page_fault_handler(uint64_t code, uintptr_t fault_addr, uintptr_t origin_addr,
+                        const IsrStackFrameWithCode *stack_frame);
 
 #endif //__ANOS_KERNEL_PAGEFAULT_H

--- a/kernel/include/panic.h
+++ b/kernel/include/panic.h
@@ -26,31 +26,32 @@ void panic_notify_smp_started(void);
 
 // Just panic...
 #define panic(msg) panic_sloc(msg, __FILE__, __LINE__)
-NORETURN_EXCEPT_TESTS void panic_sloc(const char *msg, const char *filename, const uint64_t line);
+NORETURN_EXCEPT_TESTS void panic_sloc(const char *msg, const char *filename, uint64_t line);
 
 // Generic exception panics
 #define panic_exception_with_code(vector, code, origin_addr)                                                           \
     panic_exception_with_code_sloc(vector, code, origin_addr, __FILE__, __LINE__)
 NORETURN_EXCEPT_TESTS void panic_exception_with_code_sloc(uint8_t vector, uint64_t code, uintptr_t origin_addr,
-                                                          const char *filename, const uint64_t line);
+                                                          const char *filename, uint64_t line);
 
 #define panic_exception_no_code(vector, origin_addr)                                                                   \
     panic_exception_no_code_sloc(vector, origin_addr, __FILE__, __LINE__)
 NORETURN_EXCEPT_TESTS void panic_exception_no_code_sloc(uint8_t vector, uintptr_t origin_addr, const char *filename,
-                                                        const uint64_t line);
+                                                        uint64_t line);
 
 // Specific exception panics
-#define panic_page_fault(origin_addr, fault_addr, code)                                                                \
-    panic_page_fault_sloc(origin_addr, fault_addr, code, __FILE__, __LINE__)
+#define panic_page_fault(origin_addr, fault_addr, code, origin_rbp)                                                    \
+    panic_page_fault_sloc(origin_addr, fault_addr, code, origin_rbp, __FILE__, __LINE__)
 NORETURN_EXCEPT_TESTS void panic_page_fault_sloc(uintptr_t origin_addr, uintptr_t fault_addr, uint64_t code,
-                                                 const char *filename, const uint64_t line);
+                                                 uintptr_t origin_rbp, const char *filename, uint64_t line);
 
-#define panic_general_protection_fault(code, origin_addr)                                                              \
-    panic_general_protection_fault_sloc(code, origin_addr, __FILE__, __LINE__)
+#define panic_general_protection_fault(code, origin_addr, origin_rbp)                                                  \
+    panic_general_protection_fault_sloc(code, origin_addr, origin_rbp, __FILE__, __LINE__)
 NORETURN_EXCEPT_TESTS void panic_general_protection_fault_sloc(uint64_t code, uintptr_t origin_addr,
-                                                               const char *filename, const uint64_t line);
+                                                               uintptr_t origin_rbp, const char *filename,
+                                                               uint64_t line);
 
 #define panic_double_fault(origin_addr) panic_double_fault_sloc(origin_addr, __FILE__, __LINE__)
-NORETURN_EXCEPT_TESTS void panic_double_fault_sloc(uintptr_t origin_addr, const char *filename, const uint64_t line);
+NORETURN_EXCEPT_TESTS void panic_double_fault_sloc(uintptr_t origin_addr, const char *filename, uint64_t line);
 
 #endif //__ANOS_KERNEL_PANIC_H

--- a/kernel/pagefault.c
+++ b/kernel/pagefault.c
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "isr_frame.h"
 #include "machine.h"
 #include "panic.h"
 #include "pmm/pagealloc.h"
@@ -61,8 +62,9 @@ extern MemoryRegion *physical_region;
 extern uintptr_t kernel_zero_page;
 
 // Handle page faults before we have SMP and tasking up...
-void early_page_fault_handler(const uint64_t code, const uint64_t fault_addr, const uint64_t origin_addr) {
-    panic_page_fault(origin_addr, fault_addr, code);
+void early_page_fault_handler(const uint64_t code, const uint64_t fault_addr, const uint64_t origin_addr,
+                              const IsrStackFrameWithCode stack_frame) {
+    panic_page_fault(origin_addr, fault_addr, code, stack_frame.registers.rbp);
 }
 
 // Allocate process mem if Process is non-NULL, or just unowned mem otherwise
@@ -102,7 +104,8 @@ static void copy_page_safely(const uintptr_t src_virt_page, const uintptr_t dest
 }
 
 // The full handler, replaces early once tasking and system is up
-void page_fault_handler(const uint64_t code, const uint64_t fault_addr, const uint64_t origin_addr) {
+void page_fault_handler(const uint64_t code, const uint64_t fault_addr, const uint64_t origin_addr,
+                        const IsrStackFrameWithCode *stack_frame) {
 
     tdebug("PAGEFAULT: 0x");
     tdbgx64(fault_addr);
@@ -159,7 +162,7 @@ void page_fault_handler(const uint64_t code, const uint64_t fault_addr, const ui
 
                 if (phys & 0xff) {
                     // phys alloc failed - panic anyway
-                    panic_page_fault(origin_addr, fault_addr, code);
+                    panic_page_fault(origin_addr, fault_addr, code, stack_frame->registers.rbp);
                 }
                 vdebugf("Allocated page 0x%016lx for COW destination\n", phys);
 
@@ -196,7 +199,7 @@ void page_fault_handler(const uint64_t code, const uint64_t fault_addr, const ui
 
                 if (phys & 0xff) {
                     // phys alloc failed - panic anyway
-                    panic_page_fault(origin_addr, fault_addr, code);
+                    panic_page_fault(origin_addr, fault_addr, code, stack_frame->registers.rbp);
                 }
 
                 vmm_map_page(fault_addr_page, phys, PG_USER | PG_READ | PG_WRITE | PG_PRESENT);
@@ -214,5 +217,5 @@ void page_fault_handler(const uint64_t code, const uint64_t fault_addr, const ui
     }
 
     tdebug("Unhandled #PF - panicking\n");
-    panic_page_fault(origin_addr, fault_addr, code);
+    panic_page_fault(origin_addr, fault_addr, code, stack_frame->registers.rbp);
 }

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -45,30 +45,64 @@ static SpinLock panic_lock;
 static bool smp_is_up;
 
 #ifdef ARCH_X86_64
-static void print_stack_trace() {
-    uintptr_t *ebp, *eip;
-    uint8_t count = 0;
+static char *lookup_sym(const uintptr_t addr) {
+    return "unknown"; // TODO lookup symbol
+}
 
-    __asm__ volatile("mov %%rbp, %0" : "=r"(ebp));
+static void print_stack_trace_from_origin(const uintptr_t origin_addr, const uintptr_t origin_rbp) {
+    const uintptr_t *ebp = &origin_rbp;
+    uintptr_t eip = origin_addr;
+    uint8_t count = 0;
 
     debugattr(0x0C);
     debugstr("\n\nExecution trace:\n");
 
+    debugattr(0x08);
+    debugstr("   [");
+    debugattr(0x07);
+    printhex64(eip, debugchar);
+    debugattr(0x08);
+    debugstr("] ");
+    debugattr(0xf);
+    debugstr("<");
+    debugstr(lookup_sym(eip));
+    debugstr(">\n");
+
+    ebp = (uintptr_t *)*ebp;
+
     while (ebp && (count++ < STACK_TRACE_MAX)) {
-        eip = ebp + 1;
+        eip = *(ebp + 1);
+
         debugattr(0x08);
         debugstr("   [");
         debugattr(0x07);
-        printhex64(*eip, debugchar);
+        printhex64(eip, debugchar);
         debugattr(0x08);
         debugstr("] ");
         debugattr(0xf);
-        debugstr("<unknown>\n"); // TODO lookup symbol
+        debugstr("<");
+        debugstr(lookup_sym(eip));
+        debugstr(">\n");
+
         ebp = (uintptr_t *)*ebp;
     }
 }
+
+static void print_stack_trace() {
+    uintptr_t *ebp, eip;
+
+    __asm__ volatile("mov %%rbp, %0" : "=r"(ebp));
+    eip = *(ebp + 1);
+
+    print_stack_trace_from_origin(eip, *ebp);
+}
 #else
-#define print_stack_trace()
+static void print_stack_trace_from_origin(const uintptr_t origin_addr, const uintptr_t origin_rbp) {
+    debugattr(0x0C);
+    debugstr("\n\nExecution trace not supported on this architecture yet.\n");
+}
+
+static void print_stack_trace() { print_stack_trace_from_origin(0, 0); }
 #endif
 
 static inline void print_header_vec(char *msg, const uint8_t vector) {
@@ -343,7 +377,7 @@ noreturn void panic_sloc(const char *msg, const char *filename, const uint64_t l
 }
 
 noreturn void panic_page_fault_sloc(const uintptr_t origin_addr, const uintptr_t fault_addr, const uint64_t code,
-                                    const char *filename, const uint64_t line) {
+                                    const uintptr_t origin_rbp, const char *filename, const uint64_t line) {
     disable_interrupts();
     const uint64_t lock_flags = spinlock_lock_irqsave(&panic_lock);
 
@@ -358,7 +392,7 @@ noreturn void panic_page_fault_sloc(const uintptr_t origin_addr, const uintptr_t
     print_page_fault_code(code);
     print_origin_ip(origin_addr);
     print_fault_addr(fault_addr);
-    print_stack_trace();
+    print_stack_trace_from_origin(origin_addr, origin_rbp);
     print_footer();
 
     spinlock_unlock_irqrestore(&panic_lock, lock_flags);
@@ -366,7 +400,8 @@ noreturn void panic_page_fault_sloc(const uintptr_t origin_addr, const uintptr_t
 }
 
 noreturn void panic_general_protection_fault_sloc(const uint64_t code, const uintptr_t origin_addr,
-                                                  const char *filename, const uint64_t line) {
+                                                  const uintptr_t origin_rbp, const char *filename,
+                                                  const uint64_t line) {
     disable_interrupts();
     const uint64_t lock_flags = spinlock_lock_irqsave(&panic_lock);
 
@@ -379,7 +414,7 @@ noreturn void panic_general_protection_fault_sloc(const uint64_t code, const uin
     print_cpu();
     print_code(code);
     print_origin_ip(origin_addr);
-    print_stack_trace();
+    print_stack_trace_from_origin(origin_addr, origin_rbp);
     print_footer();
 
     spinlock_unlock_irqrestore(&panic_lock, lock_flags);


### PR DESCRIPTION
* Surface stacked registers in ISRs for both architectures
* Use stacked registers to implement stack walk in faulting context
    * x86_64 only, riscv64 will need an alternative strategy.